### PR TITLE
fix(shim): settle pending requests on disconnect

### DIFF
--- a/src/shim/client/connection.ts
+++ b/src/shim/client/connection.ts
@@ -22,8 +22,11 @@ const CLIENT_ID = `client_${Date.now()}_${Math.random().toString(16).slice(2)}`;
 type PendingRequest = {
   resolve: (value: { header: ShimHeader; payloads: Buffer[] }) => void;
   reject: (error: Error) => void;
+  timeout?: ReturnType<typeof setTimeout>;
 };
 
+// A lost shim response should fail the caller instead of leaving UI flows waiting forever.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const pendingRequests = new Map<number, PendingRequest>();
 let nextRequestId = 1;
 let socket: net.Socket | null = null;
@@ -35,6 +38,41 @@ let detached = false;
 let socketDataStop: (() => void) | null = null;
 
 const detachedSubscribers = new Set<() => void>();
+
+function getShimSocketDir(): string {
+  return process.env.OPENMUX_SHIM_SOCKET_DIR ?? SHIM_SOCKET_DIR;
+}
+
+function getShimSocketPath(): string {
+  return process.env.OPENMUX_SHIM_SOCKET_PATH ?? SHIM_SOCKET_PATH;
+}
+
+function takePendingRequest(requestId: number): PendingRequest | undefined {
+  const pending = pendingRequests.get(requestId);
+  if (!pending) return undefined;
+
+  pendingRequests.delete(requestId);
+  if (pending.timeout) clearTimeout(pending.timeout);
+  return pending;
+}
+
+function rejectPendingRequests(error: Error): void {
+  for (const pending of pendingRequests.values()) {
+    if (pending.timeout) clearTimeout(pending.timeout);
+    pending.reject(error);
+  }
+  pendingRequests.clear();
+}
+
+function clearSocketState(client?: net.Socket): void {
+  // Close events can arrive late; do not let an old socket clear a newer connection.
+  if (client && socket && socket !== client) return;
+
+  socketDataStop?.();
+  socketDataStop = null;
+  socket = null;
+  reader = null;
+}
 
 /**
  * Handles incoming response frames from the shim server.
@@ -48,10 +86,9 @@ function handleResponseFrame(header: ShimHeader, payloads: Buffer[]): boolean {
     return false;
   }
 
-  const pending = pendingRequests.get(header.requestId);
+  const pending = takePendingRequest(header.requestId);
   if (!pending) return false;
 
-  pendingRequests.delete(header.requestId);
   if (header.ok) {
     pending.resolve({ header, payloads });
   } else {
@@ -75,7 +112,7 @@ const handleFrame = createFrameHandler({
  */
 async function connectSocket(): Promise<void | ShimConnectionError> {
   const mkdirResult = await errore.tryAsync<string | undefined, ShimConnectionError>({
-    try: () => fs.mkdir(SHIM_SOCKET_DIR, { recursive: true }),
+    try: () => fs.mkdir(getShimSocketDir(), { recursive: true }),
     catch: (e) =>
       new ShimConnectionError({ reason: `Failed to create socket directory: ${e}`, cause: e }),
   });
@@ -84,7 +121,7 @@ async function connectSocket(): Promise<void | ShimConnectionError> {
   const connectResult = await errore.tryAsync<void, ShimConnectionError>({
     try: () =>
       new Promise<void>((resolve, reject) => {
-        const client = net.createConnection(SHIM_SOCKET_PATH);
+        const client = net.createConnection(getShimSocketPath());
         const handleError = (error: Error) => {
           client.removeListener('connect', handleConnect);
           reject(error);
@@ -97,11 +134,9 @@ async function connectSocket(): Promise<void | ShimConnectionError> {
             // ignore, reconnect on demand
           });
           client.on('close', () => {
-            socketDataStop?.();
-            socketDataStop = null;
-            socket = null;
-            reader = null;
-            markDetached();
+            clearSocketState(client);
+            // A plain socket close is transport failure, not an explicit server detach.
+            rejectPendingRequests(new ShimConnectionError({ reason: 'Shim socket closed' }));
           });
           socketDataStop?.();
           socketDataStop = createSocketDataStream(client, reader, handleFrame);
@@ -257,7 +292,8 @@ export async function sendRequestDirect(
   payloads: ArrayBuffer[] = [],
   timeoutMs?: number
 ): Promise<{ header: ShimHeader; payloads: Buffer[] } | ShimConnectionError> {
-  if (!socket || socket.destroyed) {
+  const currentSocket = socket;
+  if (!currentSocket || currentSocket.destroyed) {
     return new ShimConnectionError({ reason: 'Shim socket not available' });
   }
 
@@ -271,23 +307,29 @@ export async function sendRequestDirect(
   };
 
   return new Promise((resolve) => {
+    const timeout = timeoutMs
+      ? setTimeout(() => {
+          const pending = takePendingRequest(requestId);
+          if (!pending) return;
+          pending.reject(new ShimConnectionError({ reason: 'Shim request timed out' }));
+        }, timeoutMs)
+      : undefined;
+
     pendingRequests.set(requestId, {
       resolve,
-      reject: (error) => resolve(new ShimConnectionError({ reason: error.message })),
+      reject: (error) =>
+        resolve(
+          error instanceof ShimConnectionError
+            ? error
+            : new ShimConnectionError({ reason: error.message })
+        ),
+      timeout,
     });
 
-    if (timeoutMs) {
-      setTimeout(() => {
-        if (!pendingRequests.has(requestId)) return;
-        pendingRequests.delete(requestId);
-        resolve(new ShimConnectionError({ reason: 'Shim request timed out' }));
-      }, timeoutMs);
-    }
-
-    socket?.write(encodeFrame(header, payloads), (err) => {
+    currentSocket.write(encodeFrame(header, payloads), (err) => {
       if (!err) return;
-      pendingRequests.delete(requestId);
-      resolve(new ShimConnectionError({ reason: err.message }));
+      const pending = takePendingRequest(requestId);
+      pending?.reject(new ShimConnectionError({ reason: err.message, cause: err }));
     });
   });
 }
@@ -304,11 +346,15 @@ export async function sendRequestDirect(
 export async function sendRequest(
   method: string,
   params?: Record<string, unknown>,
-  payloads: ArrayBuffer[] = []
+  payloads: ArrayBuffer[] = [],
+  timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
 ): Promise<{ header: ShimHeader; payloads: Buffer[] }> {
   const connectResult = await ensureConnected();
   if (connectResult instanceof ShimConnectionError) throw connectResult;
-  if (!socket) throw new ShimConnectionError({ reason: 'Shim socket not available' });
+  const currentSocket = socket;
+  if (!currentSocket || currentSocket.destroyed) {
+    throw new ShimConnectionError({ reason: 'Shim socket not available' });
+  }
 
   const requestId = nextRequestId++;
   const header: ShimHeader = {
@@ -320,8 +366,21 @@ export async function sendRequest(
   };
 
   return new Promise((resolve, reject) => {
-    pendingRequests.set(requestId, { resolve, reject });
-    socket?.write(encodeFrame(header, payloads));
+    const timeout =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            const pending = takePendingRequest(requestId);
+            if (!pending) return;
+            pending.reject(new ShimConnectionError({ reason: 'Shim request timed out' }));
+          }, timeoutMs)
+        : undefined;
+
+    pendingRequests.set(requestId, { resolve, reject, timeout });
+    currentSocket.write(encodeFrame(header, payloads), (err) => {
+      if (!err) return;
+      const pending = takePendingRequest(requestId);
+      pending?.reject(new ShimConnectionError({ reason: err.message, cause: err }));
+    });
   });
 }
 
@@ -382,6 +441,8 @@ export async function waitForShim(): Promise<void | ShimConnectionError> {
 function markDetached(): void {
   if (detached) return;
   detached = true;
+  // Detach is a terminal protocol event for this client, so all in-flight work must fail.
+  rejectPendingRequests(new ShimConnectionError({ reason: 'Shim client detached' }));
   for (const callback of detachedSubscribers) {
     callback();
   }

--- a/tests/shim/connection-lifecycle.test.ts
+++ b/tests/shim/connection-lifecycle.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import net from 'net';
+import fs from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+type TestHeader = {
+  type: string;
+  requestId?: number;
+  method?: string;
+  ok?: boolean;
+  result?: unknown;
+  error?: string;
+  payloadLengths?: number[];
+  [key: string]: unknown;
+};
+
+class TestFrameReader {
+  private buffer = Buffer.alloc(0);
+
+  feed(chunk: Buffer, onFrame: (header: TestHeader, payloads: Buffer[]) => void): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+
+    while (this.buffer.length >= 4) {
+      const frameLength = this.buffer.readUInt32BE(0);
+      if (this.buffer.length < 4 + frameLength) return;
+
+      const frame = this.buffer.subarray(4, 4 + frameLength);
+      this.buffer = this.buffer.subarray(4 + frameLength);
+      if (frame.length < 4) continue;
+
+      const headerLength = frame.readUInt32BE(0);
+      const headerEnd = 4 + headerLength;
+      const header = JSON.parse(frame.subarray(4, headerEnd).toString('utf8')) as TestHeader;
+      const payloads: Buffer[] = [];
+      let offset = headerEnd;
+
+      for (const length of header.payloadLengths ?? []) {
+        payloads.push(frame.subarray(offset, offset + length));
+        offset += length;
+      }
+
+      onFrame(header, payloads);
+    }
+  }
+}
+
+let importNonce = 0;
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+function encodeTestFrame(header: TestHeader, payloads: ArrayBuffer[] = []): Buffer {
+  const headerBuffer = Buffer.from(JSON.stringify(header), 'utf8');
+  const payloadBuffers = payloads.map((payload) => Buffer.from(payload));
+  const payloadLength = payloadBuffers.reduce((sum, payload) => sum + payload.length, 0);
+  const frameLength = 4 + headerBuffer.length + payloadLength;
+  const buffer = Buffer.alloc(4 + frameLength);
+
+  buffer.writeUInt32BE(frameLength, 0);
+  buffer.writeUInt32BE(headerBuffer.length, 4);
+  headerBuffer.copy(buffer, 8);
+
+  let offset = 8 + headerBuffer.length;
+  for (const payload of payloadBuffers) {
+    payload.copy(buffer, offset);
+    offset += payload.length;
+  }
+
+  return buffer;
+}
+
+function sendResponse(socket: net.Socket, header: TestHeader, result: unknown = {}): void {
+  socket.write(
+    encodeTestFrame({
+      type: 'response',
+      requestId: header.requestId,
+      ok: true,
+      result,
+    })
+  );
+}
+
+async function createShimTestServer(
+  handleRequest: (
+    header: TestHeader,
+    payloads: Buffer[],
+    socket: net.Socket
+  ) => void | Promise<void>
+): Promise<{
+  socketDir: string;
+  socketPath: string;
+  waitForNextSocketClose: () => Promise<void>;
+}> {
+  const socketDir = await fs.mkdtemp(join(tmpdir(), 'openmux-shim-connection-'));
+  const socketPath = join(socketDir, 'shim.sock');
+  const sockets = new Set<net.Socket>();
+  const closeWaiters: Array<() => void> = [];
+
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    const reader = new TestFrameReader();
+
+    socket.on('data', (chunk) => {
+      reader.feed(chunk as Buffer, (header, payloads) => {
+        void handleRequest(header, payloads, socket);
+      });
+    });
+
+    socket.on('close', () => {
+      sockets.delete(socket);
+      closeWaiters.shift()?.();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  cleanupTasks.push(async () => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    await fs.rm(socketDir, { recursive: true, force: true });
+  });
+
+  return {
+    socketDir,
+    socketPath,
+    waitForNextSocketClose: () =>
+      new Promise<void>((resolve) => {
+        closeWaiters.push(resolve);
+      }),
+  };
+}
+
+async function importConnection(socketDir: string, socketPath: string) {
+  process.env.OPENMUX_SHIM_SOCKET_DIR = socketDir;
+  process.env.OPENMUX_SHIM_SOCKET_PATH = socketPath;
+  return import(`../../src/shim/client/connection.ts?connectionLifecycle=${importNonce++}`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+afterEach(async () => {
+  while (cleanupTasks.length > 0) {
+    await cleanupTasks.pop()?.();
+  }
+  delete process.env.OPENMUX_SHIM_SOCKET_DIR;
+  delete process.env.OPENMUX_SHIM_SOCKET_PATH;
+});
+
+describe('shim connection lifecycle', () => {
+  test('rejects pending requests when the socket closes before response', async () => {
+    const server = await createShimTestServer((header, _payloads, socket) => {
+      if (header.method === 'hang') {
+        socket.end();
+        return;
+      }
+
+      sendResponse(socket, header, { pid: process.pid });
+    });
+    const connection = await importConnection(server.socketDir, server.socketPath);
+
+    const result = await Promise.race([
+      connection.sendRequest('hang', {}, [], 500).then(
+        () => 'resolved',
+        (error: Error) => error
+      ),
+      delay(150).then(() => 'timed out'),
+    ]);
+
+    expect(result).not.toBe('timed out');
+    expect(result).not.toBe('resolved');
+    expect((result as Error).message).toContain('Shim socket closed');
+  });
+
+  test('reconnects after an ordinary socket close', async () => {
+    const server = await createShimTestServer((header, _payloads, socket) => {
+      if (header.method === 'closeAfterResponse') {
+        sendResponse(socket, header);
+        socket.end();
+        return;
+      }
+
+      if (header.method === 'afterReconnect') {
+        sendResponse(socket, header, { value: 'ok' });
+        return;
+      }
+
+      sendResponse(socket, header, { pid: process.pid });
+    });
+    const connection = await importConnection(server.socketDir, server.socketPath);
+
+    const socketClosed = server.waitForNextSocketClose();
+    await connection.sendRequest('closeAfterResponse', {}, [], 500);
+    await socketClosed;
+    await delay(10);
+
+    const response = await connection.sendRequest('afterReconnect', {}, [], 500);
+
+    expect(response.header.result).toEqual({ value: 'ok' });
+  });
+
+  test('keeps explicit detached events terminal for the client', async () => {
+    const server = await createShimTestServer((header, _payloads, socket) => {
+      if (header.method === 'detachMe') {
+        socket.write(encodeTestFrame({ type: 'detached' }));
+        socket.end();
+        return;
+      }
+
+      sendResponse(socket, header, { pid: process.pid });
+    });
+    const connection = await importConnection(server.socketDir, server.socketPath);
+    let detachNotifications = 0;
+    const unsubscribe = connection.onShimDetached(() => {
+      detachNotifications += 1;
+    });
+
+    const detachResult = await connection.sendRequest('detachMe', {}, [], 500).catch((e) => e);
+    const reconnectResult = await connection
+      .sendRequest('afterDetach', {}, [], 500)
+      .catch((e) => e);
+
+    unsubscribe();
+
+    expect(detachNotifications).toBe(1);
+    expect((detachResult as Error).message).toContain('Shim client detached');
+    expect((reconnectResult as Error).message).toContain('Shim client detached');
+  });
+});


### PR DESCRIPTION
## Layman Explanation
Openmux talks to its background shim process over a local socket. Before this change, if openmux asked the shim for something and the connection disappeared before an answer came back, openmux could wait forever.

That is like making a phone call, the call drops, but your phone still thinks the call is active.

This PR makes those requests finish clearly. If the socket closes, the write fails, the request times out, or the server explicitly detaches the client, pending work now fails instead of hanging.

It also separates ordinary socket close from explicit detach. A normal connection close can reconnect. A server-sent `detached` frame remains terminal for this client.

## Technical Explanation
`src/shim/client/connection.ts` now centralizes pending request cleanup:

- `takePendingRequest()` removes a pending request and clears its timer.
- `rejectPendingRequests()` rejects every pending request during socket close or detach.
- `clearSocketState()` avoids stale close events clearing a newer socket.
- `sendRequest()` has a default timeout.
- `sendRequestDirect()` shares the same cleanup behavior for timeouts and write failures.
- The socket `close` handler no longer calls `markDetached()`.
- `markDetached()` is reserved for explicit protocol detach and rejects all in-flight work.

I added inline comments explaining the difference between transport failure and protocol detach, and why lost shim responses must fail callers rather than hanging UI flows.

## Why This Helps Stability
Attach, detach, pane metadata, terminal state, and shutdown flows should not freeze if the shim disappears. A request now has one clear terminal path: response, error response, timeout, write failure, socket close, or explicit detach.

## Tests
Added `tests/shim/connection-lifecycle.test.ts` covering:

- Rejecting pending requests when the socket closes before response.
- Reconnecting after an ordinary socket close.
- Keeping explicit detached events terminal for the client.

## Validation

```sh
bun test tests/shim/connection-lifecycle.test.ts
```

Result: `3 pass, 0 fail`.

The combined stability branch also passed:

```sh
bun run test
bun run typecheck
bun run lint
```

Note: this PR is intentionally split from the Bun timer compatibility PR. Full local pre-push tests require that companion fix on Bun 1.2.23.