### PR TITLE
fix(protocol): skip malformed socket frames

### DIFF
--- a/src/control/protocol.ts
+++ b/src/control/protocol.ts
@@ -6,8 +6,7 @@ export const CONTROL_PROTOCOL_VERSION = 1;
 
 const defaultSocketDir = join(homedir(), '.config', 'openmux', 'sockets');
 
-export const CONTROL_SOCKET_DIR =
-  process.env.OPENMUX_CONTROL_SOCKET_DIR ?? defaultSocketDir;
+export const CONTROL_SOCKET_DIR = process.env.OPENMUX_CONTROL_SOCKET_DIR ?? defaultSocketDir;
 
 export const CONTROL_SOCKET_PATH =
   process.env.OPENMUX_CONTROL_SOCKET_PATH ?? join(CONTROL_SOCKET_DIR, 'openmux-ui.sock');
@@ -67,17 +66,39 @@ export class FrameReader {
 
       const headerLength = frame.readUInt32BE(0);
       const headerEnd = 4 + headerLength;
+      // Bad complete frames should not crash the socket data handler.
+      if (headerEnd > frame.length) {
+        continue;
+      }
+
       const headerJson = frame.subarray(4, headerEnd).toString('utf8');
-      const header = JSON.parse(headerJson) as ControlHeader;
+      let header: ControlHeader;
+      try {
+        const parsed = JSON.parse(headerJson) as unknown;
+        if (!parsed || typeof parsed !== 'object') {
+          continue;
+        }
+        header = parsed as ControlHeader;
+      } catch {
+        continue;
+      }
 
       const payloads: Buffer[] = [];
       let offset = headerEnd;
-      const payloadLengths = header.payloadLengths ?? [];
+      const payloadLengths = Array.isArray(header.payloadLengths) ? header.payloadLengths : [];
 
       if (payloadLengths.length > 0) {
+        let validPayloads = true;
         for (const length of payloadLengths) {
+          if (!Number.isInteger(length) || length < 0 || offset + length > frame.length) {
+            validPayloads = false;
+            break;
+          }
           payloads.push(frame.subarray(offset, offset + length));
           offset += length;
+        }
+        if (!validPayloads) {
+          continue;
         }
       } else if (offset < frame.length) {
         payloads.push(frame.subarray(offset));

--- a/src/shim/protocol.ts
+++ b/src/shim/protocol.ts
@@ -91,17 +91,39 @@ export class FrameReader {
 
       const headerLength = frame.readUInt32BE(0);
       const headerEnd = 4 + headerLength;
+      // Bad complete frames should not crash the socket data handler.
+      if (headerEnd > frame.length) {
+        continue;
+      }
+
       const headerJson = frame.subarray(4, headerEnd).toString('utf8');
-      const header = JSON.parse(headerJson) as ShimHeader;
+      let header: ShimHeader;
+      try {
+        const parsed = JSON.parse(headerJson) as unknown;
+        if (!parsed || typeof parsed !== 'object') {
+          continue;
+        }
+        header = parsed as ShimHeader;
+      } catch {
+        continue;
+      }
 
       const payloads: Buffer[] = [];
       let offset = headerEnd;
-      const payloadLengths = header.payloadLengths ?? [];
+      const payloadLengths = Array.isArray(header.payloadLengths) ? header.payloadLengths : [];
 
       if (payloadLengths.length > 0) {
+        let validPayloads = true;
         for (const length of payloadLengths) {
+          if (!Number.isInteger(length) || length < 0 || offset + length > frame.length) {
+            validPayloads = false;
+            break;
+          }
           payloads.push(frame.subarray(offset, offset + length));
           offset += length;
+        }
+        if (!validPayloads) {
+          continue;
         }
       } else if (offset < frame.length) {
         payloads.push(frame.subarray(offset));

--- a/tests/control/protocol.test.ts
+++ b/tests/control/protocol.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from 'bun:test';
 import { encodeFrame, FrameReader, type ControlHeader } from '../../src/control/protocol';
+
+function encodeRawFrame(headerBytes: Buffer, declaredHeaderLength = headerBytes.length): Buffer {
+  const frameLength = 4 + headerBytes.length;
+  const buffer = Buffer.alloc(4 + frameLength);
+  buffer.writeUInt32BE(frameLength, 0);
+  buffer.writeUInt32BE(declaredHeaderLength, 4);
+  headerBytes.copy(buffer, 8);
+  return buffer;
+}
 
 function readFrames(chunks: Buffer[]): Array<{ header: ControlHeader; payloads: Buffer[] }> {
   const reader = new FrameReader();
@@ -57,5 +66,33 @@ describe('control protocol', () => {
     expect(frames).toHaveLength(1);
     expect(frames[0].payloads).toHaveLength(1);
     expect(frames[0].payloads[0].toString('utf8')).toBe('onetwo');
+  });
+
+  test('skips malformed JSON frames without throwing', () => {
+    const reader = new FrameReader();
+    const frames: Array<{ header: ControlHeader; payloads: Buffer[] }> = [];
+    const malformed = encodeRawFrame(Buffer.from('{bad json', 'utf8'));
+    const valid = encodeFrame({ type: 'event' });
+
+    expect(() => {
+      reader.feed(Buffer.concat([malformed, valid]), (header, payloads) => {
+        frames.push({ header, payloads });
+      });
+    }).not.toThrow();
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].header).toEqual({ type: 'event' });
+  });
+
+  test('skips frames with invalid header or payload lengths', () => {
+    const badHeaderLength = encodeRawFrame(Buffer.from('{}', 'utf8'), 50);
+    const badPayloadLength = encodeFrame({ type: 'event', payloadLengths: [10] }, [
+      Buffer.from('abc'),
+    ]);
+    const valid = encodeFrame({ type: 'event', payloadLengths: [1] }, [Buffer.from('z')]);
+    const frames = readFrames([Buffer.concat([badHeaderLength, badPayloadLength, valid])]);
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].payloads[0].toString('utf8')).toBe('z');
   });
 });

--- a/tests/shim/protocol.test.ts
+++ b/tests/shim/protocol.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from 'bun:test';
 import { encodeFrame, FrameReader, type ShimHeader } from '../../src/shim/protocol';
+
+function encodeRawFrame(headerBytes: Buffer, declaredHeaderLength = headerBytes.length): Buffer {
+  const frameLength = 4 + headerBytes.length;
+  const buffer = Buffer.alloc(4 + frameLength);
+  buffer.writeUInt32BE(frameLength, 0);
+  buffer.writeUInt32BE(declaredHeaderLength, 4);
+  headerBytes.copy(buffer, 8);
+  return buffer;
+}
 
 function readFrames(chunks: Buffer[]): Array<{ header: ShimHeader; payloads: Buffer[] }> {
   const reader = new FrameReader();
@@ -57,5 +66,33 @@ describe('shim protocol', () => {
     expect(frames).toHaveLength(1);
     expect(frames[0].payloads).toHaveLength(1);
     expect(frames[0].payloads[0].toString('utf8')).toBe('onetwo');
+  });
+
+  test('skips malformed JSON frames without throwing', () => {
+    const reader = new FrameReader();
+    const frames: Array<{ header: ShimHeader; payloads: Buffer[] }> = [];
+    const malformed = encodeRawFrame(Buffer.from('{bad json', 'utf8'));
+    const valid = encodeFrame({ type: 'event' });
+
+    expect(() => {
+      reader.feed(Buffer.concat([malformed, valid]), (header, payloads) => {
+        frames.push({ header, payloads });
+      });
+    }).not.toThrow();
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].header).toEqual({ type: 'event' });
+  });
+
+  test('skips frames with invalid header or payload lengths', () => {
+    const badHeaderLength = encodeRawFrame(Buffer.from('{}', 'utf8'), 50);
+    const badPayloadLength = encodeFrame({ type: 'event', payloadLengths: [10] }, [
+      Buffer.from('abc'),
+    ]);
+    const valid = encodeFrame({ type: 'event', payloadLengths: [1] }, [Buffer.from('z')]);
+    const frames = readFrames([Buffer.concat([badHeaderLength, badPayloadLength, valid])]);
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].payloads[0].toString('utf8')).toBe('z');
   });
 });


### PR DESCRIPTION
## Layman Explanation
Openmux sends socket messages as small packages called frames. Each frame has a JSON label and optional binary data.

Before this change, one malformed frame could throw inside the socket reader. That is like one damaged envelope shutting down the whole mailroom.

This PR makes shim and control protocol readers skip bad complete frames instead of throwing.

## Technical Explanation
Both `src/shim/protocol.ts` and `src/control/protocol.ts` now defensively validate frame internals:

- Header length must fit inside the frame.
- JSON parsing is wrapped in `try/catch`.
- Parsed headers must be non-null objects.
- `payloadLengths` must be an array before use.
- Payload lengths must be non-negative integers.
- Payload slices must fit inside the frame.

Bad complete frames are ignored and later valid frames in the same chunk can still be processed.

I added inline comments explaining that malformed complete frames should not crash the socket data handler.

## Why This Helps Stability
Socket parsers sit on a dangerous boundary. Even local sockets can receive corrupted writes, old-version frames, test frames, or buggy payloads. The parser should fail closed for that frame, not crash the caller.

## Tests
Updated:

- `tests/shim/protocol.test.ts`
- `tests/control/protocol.test.ts`

New coverage verifies:

- Malformed JSON frames do not throw.
- Invalid header lengths are skipped.
- Invalid payload lengths are skipped.
- Valid frames after malformed frames are still processed.

## Validation

```sh
bun test tests/shim/protocol.test.ts tests/control/protocol.test.ts
```

Result: `12 pass, 0 fail`.

The combined stability branch also passed:

```sh
bun run test
bun run typecheck
bun run lint
```