### PR TITLE
fix(server): avoid unlinking active sockets

### DIFF
--- a/src/control/server.ts
+++ b/src/control/server.ts
@@ -7,7 +7,14 @@ import type { LayoutState } from '../core/operations/layout-actions';
 import type { ITerminalEmulator } from '../terminal/emulator-interface';
 import type { SessionMetadata } from '../core/types';
 import { SessionStorageError } from '../effect/errors';
-import { CONTROL_PROTOCOL_VERSION, CONTROL_SOCKET_DIR, CONTROL_SOCKET_PATH, encodeFrame, FrameReader, type ControlHeader } from './protocol';
+import {
+  CONTROL_PROTOCOL_VERSION,
+  CONTROL_SOCKET_DIR,
+  CONTROL_SOCKET_PATH,
+  encodeFrame,
+  FrameReader,
+  type ControlHeader,
+} from './protocol';
 import { parsePaneSelector, resolvePaneSelector } from './targets';
 import { captureEmulator, type CaptureFormat } from './capture';
 
@@ -19,9 +26,18 @@ export type ControlServerDeps = {
   splitPane: (direction: 'horizontal' | 'vertical') => void;
   writeToPty: (ptyId: string, data: string) => void;
   getEmulator: (ptyId: string) => ITerminalEmulator | null;
-  fetchTerminalState: (ptyId: string, options?: { force?: boolean }) => Promise<TerminalState | null>;
-  fetchScrollState: (ptyId: string, options?: { force?: boolean }) => Promise<TerminalScrollState | null>;
-  capturePty?: (ptyId: string, options: { lines: number; format: CaptureFormat; raw?: boolean }) => Promise<string | null>;
+  fetchTerminalState: (
+    ptyId: string,
+    options?: { force?: boolean }
+  ) => Promise<TerminalState | null>;
+  fetchScrollState: (
+    ptyId: string,
+    options?: { force?: boolean }
+  ) => Promise<TerminalScrollState | null>;
+  capturePty?: (
+    ptyId: string,
+    options: { lines: number; format: CaptureFormat; raw?: boolean }
+  ) => Promise<string | null>;
   isPtyActive: (ptyId: string) => boolean;
   createSession: (name?: string) => Promise<SessionMetadata | SessionStorageError>;
   getActiveSessionId: () => string | null | undefined;
@@ -32,7 +48,12 @@ export type ControlServer = {
   socketPath: string;
 };
 
-type ControlErrorCode = 'invalid_request' | 'not_found' | 'ambiguous' | 'internal' | 'session_creation_failed';
+type ControlErrorCode =
+  | 'invalid_request'
+  | 'not_found'
+  | 'ambiguous'
+  | 'internal'
+  | 'session_creation_failed';
 
 /** Error processing control request */
 export class ControlRequestError extends errore.createTaggedError({
@@ -40,6 +61,60 @@ export class ControlRequestError extends errore.createTaggedError({
   message: 'Control request failed: $reason',
 }) {
   code: ControlErrorCode = 'internal';
+}
+
+function getControlSocketDir(): string {
+  return process.env.OPENMUX_CONTROL_SOCKET_DIR ?? CONTROL_SOCKET_DIR;
+}
+
+function getControlSocketPath(): string {
+  return process.env.OPENMUX_CONTROL_SOCKET_PATH ?? CONTROL_SOCKET_PATH;
+}
+
+async function socketAcceptsConnections(socketPath: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection(socketPath);
+    const timeout = setTimeout(() => {
+      cleanup();
+      client.destroy();
+      reject(new Error(`Timed out checking control socket: ${socketPath}`));
+    }, 250);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      client.removeAllListeners('connect');
+      client.removeAllListeners('error');
+    };
+
+    client.once('connect', () => {
+      cleanup();
+      client.end();
+      resolve(true);
+    });
+
+    client.once('error', (error: NodeJS.ErrnoException) => {
+      cleanup();
+      client.destroy();
+      if (error.code === 'ENOENT' || error.code === 'ECONNREFUSED') {
+        resolve(false);
+        return;
+      }
+      reject(error);
+    });
+  });
+}
+
+async function prepareSocketFile(socketPath: string): Promise<void> {
+  // Only unlink stale files. Removing an active Unix socket path orphans the running server.
+  if (await socketAcceptsConnections(socketPath)) {
+    throw new Error(`Control socket already in use: ${socketPath}`);
+  }
+
+  await fs.unlink(socketPath).catch((e: NodeJS.ErrnoException) => {
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
+  });
 }
 
 function parseWorkspaceId(value: unknown): WorkspaceId | undefined {
@@ -270,8 +345,9 @@ async function handlePaneCapture(
     const end = Math.min(scrollbackLength, start + lines);
     const count = Math.max(0, end - start);
     if (count > 0) {
-      await (emulator as { prefetchScrollbackLines: (offset: number, count: number) => Promise<void> })
-        .prefetchScrollbackLines(start, count);
+      await (
+        emulator as { prefetchScrollbackLines: (offset: number, count: number) => Promise<void> }
+      ).prefetchScrollbackLines(start, count);
     }
   }
 
@@ -285,10 +361,11 @@ async function handlePaneCapture(
 }
 
 export async function startControlServer(deps: ControlServerDeps): Promise<ControlServer> {
-  await fs.mkdir(CONTROL_SOCKET_DIR, { recursive: true });
-  await fs.unlink(CONTROL_SOCKET_PATH).catch((e) => {
-    console.warn('[control] Failed to unlink control socket:', e);
-  });
+  const socketDir = getControlSocketDir();
+  const socketPath = getControlSocketPath();
+
+  await fs.mkdir(socketDir, { recursive: true });
+  await prepareSocketFile(socketPath);
 
   const server = net.createServer((socket) => {
     const reader = new FrameReader();
@@ -342,7 +419,11 @@ export async function startControlServer(deps: ControlServerDeps): Promise<Contr
               sendError(requestId, `Unknown method: ${method}`, 'invalid_request');
           }
         },
-        catch: (e: unknown) => new ControlRequestError({ reason: e instanceof Error ? e.message : 'Request failed', cause: e }),
+        catch: (e: unknown) =>
+          new ControlRequestError({
+            reason: e instanceof Error ? e.message : 'Request failed',
+            cause: e,
+          }),
       });
 
       if (result instanceof ControlRequestError) {
@@ -360,14 +441,14 @@ export async function startControlServer(deps: ControlServerDeps): Promise<Contr
 
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
-    server.listen(CONTROL_SOCKET_PATH, () => resolve());
+    server.listen(socketPath, () => resolve());
   });
 
   return {
-    socketPath: CONTROL_SOCKET_PATH,
+    socketPath,
     close: async () => {
       await new Promise<void>((resolve) => server.close(() => resolve()));
-      await fs.unlink(CONTROL_SOCKET_PATH).catch((e) => {
+      await fs.unlink(socketPath).catch((e) => {
         console.warn('[control] Failed to unlink control socket on close:', e);
       });
     },

--- a/src/shim/server-socket.ts
+++ b/src/shim/server-socket.ts
@@ -1,0 +1,62 @@
+import net from 'net';
+import fs from 'fs/promises';
+
+import { ShimConnectionError } from '../effect/errors';
+
+async function socketAcceptsConnections(
+  socketPath: string
+): Promise<boolean | ShimConnectionError> {
+  return new Promise((resolve) => {
+    const client = net.createConnection(socketPath);
+    const timeout = setTimeout(() => {
+      cleanup();
+      client.destroy();
+      resolve(new ShimConnectionError({ reason: `Timed out checking shim socket: ${socketPath}` }));
+    }, 250);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      client.removeAllListeners('connect');
+      client.removeAllListeners('error');
+    };
+
+    client.once('connect', () => {
+      cleanup();
+      client.end();
+      resolve(true);
+    });
+
+    client.once('error', (error: NodeJS.ErrnoException) => {
+      cleanup();
+      client.destroy();
+      if (error.code === 'ENOENT' || error.code === 'ECONNREFUSED') {
+        resolve(false);
+        return;
+      }
+      resolve(
+        new ShimConnectionError({
+          reason: `Failed to check shim socket ${socketPath}: ${error.message}`,
+          cause: error,
+        })
+      );
+    });
+  });
+}
+
+/** Removes a stale socket file without replacing an active shim server. */
+export async function prepareShimSocketFile(
+  socketPath: string
+): Promise<void | ShimConnectionError> {
+  // Only unlink stale files. Removing an active Unix socket path orphans the running server.
+  const activeSocket = await socketAcceptsConnections(socketPath);
+  if (activeSocket instanceof ShimConnectionError) return activeSocket;
+  if (activeSocket) {
+    return new ShimConnectionError({ reason: `Shim socket already in use: ${socketPath}` });
+  }
+
+  try {
+    await fs.unlink(socketPath);
+  } catch {
+    // Ignore missing file
+  }
+}

--- a/src/shim/server.ts
+++ b/src/shim/server.ts
@@ -5,6 +5,7 @@ import * as errore from 'errore';
 import { FrameReader } from './protocol';
 import { createServerHandlers, type ShimServerOptions } from './server-handlers';
 import { createShimServerState, resetShimServerState } from './server-state';
+import { prepareShimSocketFile } from './server-socket';
 import { ShimConnectionError } from '../effect/errors';
 
 const shimState = createShimServerState();
@@ -24,18 +25,6 @@ async function ensureSocketDir(socketDir: string): Promise<void | ShimConnection
 }
 
 /**
- * Removes the socket file if it exists, ignoring errors.
- * @param socketPath - Path to the socket file to remove
- */
-async function removeSocketFile(socketPath: string): Promise<void> {
-  try {
-    await fs.unlink(socketPath);
-  } catch {
-    // Ignore missing file
-  }
-}
-
-/**
  * Starts the shim server listening on a Unix socket.
  * Creates server handlers and manages client connections with single-client lock semantics.
  * @param options - Optional server configuration including socket path and PTY provider
@@ -44,14 +33,15 @@ async function removeSocketFile(socketPath: string): Promise<void> {
 export async function startShimServer(
   options?: ShimServerOptions
 ): Promise<net.Server | ShimConnectionError> {
-  resetShimServerState(shimState);
-
   const handlers = createServerHandlers(shimState, options);
 
   const dirResult = await ensureSocketDir(handlers.socketDir);
   if (dirResult instanceof ShimConnectionError) return dirResult;
 
-  await removeSocketFile(handlers.socketPath);
+  const socketResult = await prepareShimSocketFile(handlers.socketPath);
+  if (socketResult instanceof ShimConnectionError) return socketResult;
+
+  resetShimServerState(shimState);
 
   const server = net.createServer((socket) => {
     const frameReader = new FrameReader();

--- a/tests/control/server-client.test.ts
+++ b/tests/control/server-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "bun:test";
+import { describe, expect, test, vi } from 'bun:test';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -28,6 +28,65 @@ function createLayoutState(workspace: Workspace): LayoutState {
 }
 
 describe('control server smoke', () => {
+  test('does not replace an active control socket on startup', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openmux-control-'));
+    process.env.OPENMUX_CONTROL_SOCKET_DIR = tempDir;
+    process.env.OPENMUX_CONTROL_SOCKET_PATH = path.join(tempDir, 'openmux-ui.sock');
+
+    await mockControlProtocol();
+
+    const { startControlServer } = await import('../../src/control/server');
+    const { connectControlClient } = await import('../../src/control/client');
+
+    const workspace: Workspace = {
+      id: 1,
+      label: undefined,
+      mainPane: { id: 'pane-1', ptyId: 'pty-1' },
+      stackPanes: [],
+      focusedPaneId: 'pane-1',
+      activeStackIndex: 0,
+      layoutMode: 'vertical',
+      zoomed: false,
+    };
+    const layoutState = createLayoutState(workspace);
+    const deps = {
+      getLayoutState: () => layoutState,
+      getActiveWorkspace: () => workspace,
+      switchWorkspace: () => {},
+      focusPane: () => {},
+      splitPane: () => {},
+      writeToPty: () => {},
+      getEmulator: () => null as ITerminalEmulator | null,
+      fetchTerminalState: async (_ptyId: string, _options?: { force?: boolean }) => null,
+      fetchScrollState: async (_ptyId: string, _options?: { force?: boolean }) => null,
+      capturePty: async () => null,
+      isPtyActive: () => true,
+      createSession: async () => ({
+        id: 'session-1',
+        name: 'test',
+        createdAt: Date.now(),
+        lastSwitchedAt: Date.now(),
+        autoNamed: false,
+      }),
+      getActiveSessionId: () => 'session-1',
+    };
+
+    const serverA = await startControlServer(deps);
+    const serverBError = await startControlServer(deps).catch((e) => e);
+
+    expect(serverBError).toBeInstanceOf(Error);
+    expect((serverBError as Error).message).toContain('Control socket already in use');
+
+    const client = await connectControlClient({ socketPath: serverA.socketPath, timeoutMs: 500 });
+    const response = await client.request('hello', undefined, 500);
+
+    expect(response.header.ok).toBe(true);
+
+    client.close();
+    await serverA.close();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
   test('pane.send routes through control socket', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openmux-control-'));
     process.env.OPENMUX_CONTROL_SOCKET_DIR = tempDir;

--- a/tests/shim/server-socket.test.ts
+++ b/tests/shim/server-socket.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import net from 'net';
+import fs from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { prepareShimSocketFile } from '../../src/shim/server-socket';
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+async function listen(socketPath: string): Promise<net.Server> {
+  const server = net.createServer((socket) => {
+    socket.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  cleanupTasks.push(
+    () =>
+      new Promise<void>((resolve) => {
+        try {
+          server.close(() => resolve());
+        } catch {
+          resolve();
+        }
+      })
+  );
+  return server;
+}
+
+async function connect(socketPath: string): Promise<void> {
+  const socket = net.createConnection(socketPath);
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', resolve);
+    socket.once('error', reject);
+  });
+  socket.destroy();
+}
+
+afterEach(async () => {
+  while (cleanupTasks.length > 0) {
+    await cleanupTasks.pop()?.();
+  }
+});
+
+describe('shim server socket preparation', () => {
+  test('does not unlink an active shim socket', async () => {
+    const socketDir = await fs.mkdtemp(join(tmpdir(), 'openmux-shim-socket-'));
+    const socketPath = join(socketDir, 'shim.sock');
+    cleanupTasks.push(() => fs.rm(socketDir, { recursive: true, force: true }));
+    await listen(socketPath);
+
+    const result = await prepareShimSocketFile(socketPath);
+
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toContain('Shim socket already in use');
+    await expect(connect(socketPath)).resolves.toBeUndefined();
+  });
+
+  test('removes stale shim socket files', async () => {
+    const socketDir = await fs.mkdtemp(join(tmpdir(), 'openmux-shim-socket-'));
+    const socketPath = join(socketDir, 'shim.sock');
+    cleanupTasks.push(() => fs.rm(socketDir, { recursive: true, force: true }));
+    const server = await listen(socketPath);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    const result = await prepareShimSocketFile(socketPath);
+
+    expect(result).toBeUndefined();
+    await expect(fs.stat(socketPath)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Layman Explanation
Openmux servers use Unix socket files as their address. Before this change, startup removed an existing socket file before listening.

That is safe when the old socket file is stale. It is unsafe when another server is still actively using that socket.

That is like opening a new front desk and ripping the sign off the old front desk while it is still serving people.

This PR checks whether the existing socket is alive before deleting it.

## Technical Explanation
The shim server now uses `prepareShimSocketFile()` in `src/shim/server-socket.ts`.

The startup flow now:

- Attempts to connect to the existing socket path.
- Treats a successful connection as an active server and returns a clear error.
- Treats `ENOENT` and `ECONNREFUSED` as missing or stale sockets.
- Only unlinks stale socket files.

The control server now applies equivalent protection and reads socket env overrides at startup time, which also makes temp-socket tests reliable.

I added inline comments explaining that removing an active Unix socket path can orphan a running server.

## Why This Helps Stability
Starting a second instance should not silently make the first server unreachable by path. This protects detach/attach behavior and client routing from accidental socket-path theft.

## Tests
Added/updated:

- `tests/shim/server-socket.test.ts`
- `tests/control/server-client.test.ts`

Coverage verifies:

- Active shim socket paths are not unlinked.
- Stale shim socket paths are removed.
- A second control server cannot replace an active control socket.
- The original control server remains reachable.

## Validation

```sh
bun test tests/shim/server-socket.test.ts tests/control/server-client.test.ts
```

Result: `4 pass, 0 fail`.

The combined stability branch also passed:

```sh
bun run test
bun run typecheck
bun run lint
```