### PR TITLE
fix(imports): avoid circular initialization failures

### DIFF
--- a/src/effect/services/pty/session-factory.ts
+++ b/src/effect/services/pty/session-factory.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import * as errore from 'errore';
 import { spawnAsync } from '../../../../native/zig-pty/ts/index';
 import { createGhosttyVTEmulator } from '../../../terminal/ghostty-vt/emulator';
-import { ArchivedTerminalEmulator } from '../../../terminal/archived-emulator';
 import { TerminalQueryPassthrough } from '../../../terminal/terminal-query-passthrough';
 import { createSyncModeParser } from '../../../terminal/sync-mode-parser';
 import { getCapabilityEnvironment } from '../../../terminal/capabilities';
@@ -27,8 +26,13 @@ import type { ScrollbackArchiveManager } from '../../../terminal/scrollback-arch
 import { ScrollbackArchiver } from './scrollback-archiver';
 import { getConfigDir } from '../../../core/user-config';
 
-const DEFAULT_CELL_WIDTH = 8;
-const DEFAULT_CELL_HEIGHT = 16;
+function defaultCellWidth(): number {
+  return 8;
+}
+
+function defaultCellHeight(): number {
+  return 16;
+}
 
 export interface SessionFactoryDeps {
   colors: TerminalColors;
@@ -73,10 +77,10 @@ export async function createSession(
   const pixelHeight = hasPixels ? options.pixelHeight : undefined;
   const cellWidth = hasPixels
     ? Math.max(1, Math.floor((pixelWidth ?? 0) / cols))
-    : DEFAULT_CELL_WIDTH;
+    : defaultCellWidth();
   const cellHeight = hasPixels
     ? Math.max(1, Math.floor((pixelHeight ?? 0) / rows))
-    : DEFAULT_CELL_HEIGHT;
+    : defaultCellHeight();
   const cwd = options.cwd ?? process.cwd();
   const shell = deps.defaultShell;
   const shellName = shell.split('/').pop() ?? '';
@@ -100,6 +104,8 @@ export async function createSession(
     rootDir: path.join(scrollbackRoot, String(id)),
     manager: deps.scrollbackArchiveManager,
   });
+  // Dynamic import keeps circular test imports from touching the class before initialization.
+  const { ArchivedTerminalEmulator } = await import('../../../terminal/archived-emulator');
   const emulator = new ArchivedTerminalEmulator(liveEmulator, scrollbackArchive);
 
   // Create terminal query passthrough for handling terminal queries
@@ -157,8 +163,8 @@ export async function createSession(
     rows,
     cellWidth,
     cellHeight,
-    pixelWidth: hasPixels ? pixelWidth! : cols * DEFAULT_CELL_WIDTH,
-    pixelHeight: hasPixels ? pixelHeight! : rows * DEFAULT_CELL_HEIGHT,
+    pixelWidth: hasPixels ? pixelWidth! : cols * defaultCellWidth(),
+    pixelHeight: hasPixels ? pixelHeight! : rows * defaultCellHeight(),
     cwd,
     cwdReported: false,
     shell,

--- a/src/shim/server-handlers.ts
+++ b/src/shim/server-handlers.ts
@@ -20,18 +20,20 @@ import {
   detachClient,
   applyHostColors,
   type ShimHandlerContext,
-  type WithPty,
   type ShimServerOptions,
 } from './handlers';
 import type { ShimServerState } from './server-state';
 
-const defaultWithPty: WithPty = async (fn) => {
+// Function declaration avoids TDZ failures when tests import this module through cycles.
+async function defaultWithPty<A>(
+  fn: (pty: ReturnType<typeof getPtyService>) => Promise<A | Error> | A | Error
+): Promise<A | Error> {
   if (!hasServices()) {
     return new ServicesNotInitializedError({ operation: 'withPty' });
   }
   const pty = getPtyService();
   return await fn(pty);
-};
+}
 
 /**
  * Creates shim server handlers with configured context.


### PR DESCRIPTION
## Layman Explanation
Some modules were touching values before JavaScript had finished setting them up during circular imports.

That is like two people trying to use each other's keys before either person has received their own key.

This PR removes two circular-initialization failure points.

## Technical Explanation
JavaScript `const` bindings have a temporal dead zone during module initialization. In cyclic imports, another module can observe a binding before initialization completes and trigger `ReferenceError: Cannot access ... before initialization`.

This PR changes:

- `defaultWithPty` from a `const` function expression to a hoisted function declaration in `src/shim/server-handlers.ts`.
- PTY default cell constants into hoisted helper functions in `src/effect/services/pty/session-factory.ts`.
- `ArchivedTerminalEmulator` from a top-level import to a dynamic import inside `createSession()`.

I added inline comments explaining the TDZ/circular-import motivation directly in the changed files.

## Why This Helps Stability
Import-order-dependent behavior makes tests and runtime initialization fragile. Hoisted declarations and delayed imports make these paths less sensitive to module load order.

## Tests
Validated the PTY session factory path that previously hit circular initialization issues.

## Validation

```sh
bun test tests/effect/services/pty/session-factory.test.ts
```

Result: `3 pass, 0 fail`.

The combined stability branch also passed:

```sh
bun run test
bun run typecheck
bun run lint
```