### PR TITLE
fix(shim): settle pending requests on disconnect

### DIFF
--- a/src/shim/client/connection.ts
+++ b/src/shim/client/connection.ts
@@ -22,8 +22,11 @@ const CLIENT_ID = `client_${Date.now()}_${Math.random().toString(16).slice(2)}`;
 type PendingRequest = {
   resolve: (value: { header: ShimHeader; payloads: Buffer[] }) => void;
   reject: (error: Error) => void;
+  timeout?: ReturnType<typeof setTimeout>;
 };
 
+// A lost shim response should fail the caller instead of leaving UI flows waiting forever.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const pendingRequests = new Map<number, PendingRequest>();
 let nextRequestId = 1;
 let socket: net.Socket | null = null;
@@ -37,6 +40,60 @@ let socketDataStop: (() => void) | null = null;
 const detachedSubscribers = new Set<() => void>();
 
 /**
+ * Resolves the shim socket directory at call time so tests can override after process start.
+ * `protocol.ts` already exports an env-driven constant captured at module load — that covers
+ * production startup; this getter covers per-test substitution.
+ */
+function getShimSocketDir(): string {
+  return process.env.OPENMUX_SHIM_SOCKET_DIR ?? SHIM_SOCKET_DIR;
+}
+
+/**
+ * Resolves the shim socket path at call time. See `getShimSocketDir` for the rationale.
+ */
+function getShimSocketPath(): string {
+  return process.env.OPENMUX_SHIM_SOCKET_PATH ?? SHIM_SOCKET_PATH;
+}
+
+/**
+ * Removes a pending request from the registry and cancels its timeout in one step.
+ * Returns the entry so the caller can resolve or reject it.
+ */
+function takePendingRequest(requestId: number): PendingRequest | undefined {
+  const pending = pendingRequests.get(requestId);
+  if (!pending) return undefined;
+
+  pendingRequests.delete(requestId);
+  if (pending.timeout) clearTimeout(pending.timeout);
+  return pending;
+}
+
+/**
+ * Rejects every in-flight request with the given error and clears the registry.
+ * Used on terminal transport events (socket close, explicit detach).
+ */
+function rejectPendingRequests(error: Error): void {
+  for (const pending of pendingRequests.values()) {
+    if (pending.timeout) clearTimeout(pending.timeout);
+    pending.reject(error);
+  }
+  pendingRequests.clear();
+}
+
+/**
+ * Tears down references tied to a closed socket, but only if it is still the current one.
+ * Late `close` events from a stale socket must not wipe a freshly reconnected one.
+ */
+function clearSocketState(client: net.Socket): void {
+  if (socket && socket !== client) return;
+
+  socketDataStop?.();
+  socketDataStop = null;
+  socket = null;
+  reader = null;
+}
+
+/**
  * Handles incoming response frames from the shim server.
  * Resolves pending requests based on requestId matching.
  * @param header - Response frame header
@@ -48,10 +105,9 @@ function handleResponseFrame(header: ShimHeader, payloads: Buffer[]): boolean {
     return false;
   }
 
-  const pending = pendingRequests.get(header.requestId);
+  const pending = takePendingRequest(header.requestId);
   if (!pending) return false;
 
-  pendingRequests.delete(header.requestId);
   if (header.ok) {
     pending.resolve({ header, payloads });
   } else {
@@ -75,7 +131,7 @@ const handleFrame = createFrameHandler({
  */
 async function connectSocket(): Promise<void | ShimConnectionError> {
   const mkdirResult = await errore.tryAsync<string | undefined, ShimConnectionError>({
-    try: () => fs.mkdir(SHIM_SOCKET_DIR, { recursive: true }),
+    try: () => fs.mkdir(getShimSocketDir(), { recursive: true }),
     catch: (e) =>
       new ShimConnectionError({ reason: `Failed to create socket directory: ${e}`, cause: e }),
   });
@@ -84,7 +140,7 @@ async function connectSocket(): Promise<void | ShimConnectionError> {
   const connectResult = await errore.tryAsync<void, ShimConnectionError>({
     try: () =>
       new Promise<void>((resolve, reject) => {
-        const client = net.createConnection(SHIM_SOCKET_PATH);
+        const client = net.createConnection(getShimSocketPath());
         const handleError = (error: Error) => {
           client.removeListener('connect', handleConnect);
           reject(error);
@@ -97,11 +153,9 @@ async function connectSocket(): Promise<void | ShimConnectionError> {
             // ignore, reconnect on demand
           });
           client.on('close', () => {
-            socketDataStop?.();
-            socketDataStop = null;
-            socket = null;
-            reader = null;
-            markDetached();
+            clearSocketState(client);
+            // A plain socket close is transport failure, not an explicit server detach.
+            rejectPendingRequests(new ShimConnectionError({ reason: 'Shim socket closed' }));
           });
           socketDataStop?.();
           socketDataStop = createSocketDataStream(client, reader, handleFrame);
@@ -257,7 +311,8 @@ export async function sendRequestDirect(
   payloads: ArrayBuffer[] = [],
   timeoutMs?: number
 ): Promise<{ header: ShimHeader; payloads: Buffer[] } | ShimConnectionError> {
-  if (!socket || socket.destroyed) {
+  const currentSocket = socket;
+  if (!currentSocket || currentSocket.destroyed) {
     return new ShimConnectionError({ reason: 'Shim socket not available' });
   }
 
@@ -271,23 +326,29 @@ export async function sendRequestDirect(
   };
 
   return new Promise((resolve) => {
+    const timeout = timeoutMs
+      ? setTimeout(() => {
+          const pending = takePendingRequest(requestId);
+          if (!pending) return;
+          pending.reject(new ShimConnectionError({ reason: 'Shim request timed out' }));
+        }, timeoutMs)
+      : undefined;
+
     pendingRequests.set(requestId, {
       resolve,
-      reject: (error) => resolve(new ShimConnectionError({ reason: error.message })),
+      reject: (error) =>
+        resolve(
+          error instanceof ShimConnectionError
+            ? error
+            : new ShimConnectionError({ reason: error.message })
+        ),
+      timeout,
     });
 
-    if (timeoutMs) {
-      setTimeout(() => {
-        if (!pendingRequests.has(requestId)) return;
-        pendingRequests.delete(requestId);
-        resolve(new ShimConnectionError({ reason: 'Shim request timed out' }));
-      }, timeoutMs);
-    }
-
-    socket?.write(encodeFrame(header, payloads), (err) => {
+    currentSocket.write(encodeFrame(header, payloads), (err) => {
       if (!err) return;
-      pendingRequests.delete(requestId);
-      resolve(new ShimConnectionError({ reason: err.message }));
+      const pending = takePendingRequest(requestId);
+      pending?.reject(new ShimConnectionError({ reason: err.message, cause: err }));
     });
   });
 }
@@ -304,11 +365,15 @@ export async function sendRequestDirect(
 export async function sendRequest(
   method: string,
   params?: Record<string, unknown>,
-  payloads: ArrayBuffer[] = []
+  payloads: ArrayBuffer[] = [],
+  timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
 ): Promise<{ header: ShimHeader; payloads: Buffer[] }> {
   const connectResult = await ensureConnected();
   if (connectResult instanceof ShimConnectionError) throw connectResult;
-  if (!socket) throw new ShimConnectionError({ reason: 'Shim socket not available' });
+  const currentSocket = socket;
+  if (!currentSocket || currentSocket.destroyed) {
+    throw new ShimConnectionError({ reason: 'Shim socket not available' });
+  }
 
   const requestId = nextRequestId++;
   const header: ShimHeader = {
@@ -320,8 +385,21 @@ export async function sendRequest(
   };
 
   return new Promise((resolve, reject) => {
-    pendingRequests.set(requestId, { resolve, reject });
-    socket?.write(encodeFrame(header, payloads));
+    const timeout =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            const pending = takePendingRequest(requestId);
+            if (!pending) return;
+            pending.reject(new ShimConnectionError({ reason: 'Shim request timed out' }));
+          }, timeoutMs)
+        : undefined;
+
+    pendingRequests.set(requestId, { resolve, reject, timeout });
+    currentSocket.write(encodeFrame(header, payloads), (err) => {
+      if (!err) return;
+      const pending = takePendingRequest(requestId);
+      pending?.reject(new ShimConnectionError({ reason: err.message, cause: err }));
+    });
   });
 }
 
@@ -382,6 +460,8 @@ export async function waitForShim(): Promise<void | ShimConnectionError> {
 function markDetached(): void {
   if (detached) return;
   detached = true;
+  // Detach is a terminal protocol event for this client, so all in-flight work must fail.
+  rejectPendingRequests(new ShimConnectionError({ reason: 'Shim client detached' }));
   for (const callback of detachedSubscribers) {
     callback();
   }

--- a/tests/shim/connection-lifecycle.test.ts
+++ b/tests/shim/connection-lifecycle.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import net from 'net';
+import fs from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+type TestHeader = {
+  type: string;
+  requestId?: number;
+  method?: string;
+  ok?: boolean;
+  result?: unknown;
+  error?: string;
+  payloadLengths?: number[];
+  [key: string]: unknown;
+};
+
+class TestFrameReader {
+  private buffer = Buffer.alloc(0);
+
+  feed(chunk: Buffer, onFrame: (header: TestHeader, payloads: Buffer[]) => void): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+
+    while (this.buffer.length >= 4) {
+      const frameLength = this.buffer.readUInt32BE(0);
+      if (this.buffer.length < 4 + frameLength) return;
+
+      const frame = this.buffer.subarray(4, 4 + frameLength);
+      this.buffer = this.buffer.subarray(4 + frameLength);
+      if (frame.length < 4) continue;
+
+      const headerLength = frame.readUInt32BE(0);
+      const headerEnd = 4 + headerLength;
+      const header = JSON.parse(frame.subarray(4, headerEnd).toString('utf8')) as TestHeader;
+      const payloads: Buffer[] = [];
+      let offset = headerEnd;
+
+      for (const length of header.payloadLengths ?? []) {
+        payloads.push(frame.subarray(offset, offset + length));
+        offset += length;
+      }
+
+      onFrame(header, payloads);
+    }
+  }
+}
+
+let importNonce = 0;
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+function encodeTestFrame(header: TestHeader, payloads: ArrayBuffer[] = []): Buffer {
+  const headerBuffer = Buffer.from(JSON.stringify(header), 'utf8');
+  const payloadBuffers = payloads.map((payload) => Buffer.from(payload));
+  const payloadLength = payloadBuffers.reduce((sum, payload) => sum + payload.length, 0);
+  const frameLength = 4 + headerBuffer.length + payloadLength;
+  const buffer = Buffer.alloc(4 + frameLength);
+
+  buffer.writeUInt32BE(frameLength, 0);
+  buffer.writeUInt32BE(headerBuffer.length, 4);
+  headerBuffer.copy(buffer, 8);
+
+  let offset = 8 + headerBuffer.length;
+  for (const payload of payloadBuffers) {
+    payload.copy(buffer, offset);
+    offset += payload.length;
+  }
+
+  return buffer;
+}
+
+function sendResponse(socket: net.Socket, header: TestHeader, result: unknown = {}): void {
+  socket.write(
+    encodeTestFrame({
+      type: 'response',
+      requestId: header.requestId,
+      ok: true,
+      result,
+    })
+  );
+}
+
+async function createShimTestServer(
+  handleRequest: (
+    header: TestHeader,
+    payloads: Buffer[],
+    socket: net.Socket
+  ) => void | Promise<void>
+): Promise<{
+  socketDir: string;
+  socketPath: string;
+  waitForNextSocketClose: () => Promise<void>;
+}> {
+  const socketDir = await fs.mkdtemp(join(tmpdir(), 'openmux-shim-connection-'));
+  const socketPath = join(socketDir, 'shim.sock');
+  const sockets = new Set<net.Socket>();
+  const closeWaiters: Array<() => void> = [];
+
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    const reader = new TestFrameReader();
+
+    socket.on('data', (chunk) => {
+      reader.feed(chunk as Buffer, (header, payloads) => {
+        void handleRequest(header, payloads, socket);
+      });
+    });
+
+    socket.on('close', () => {
+      sockets.delete(socket);
+      closeWaiters.shift()?.();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  cleanupTasks.push(async () => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    await fs.rm(socketDir, { recursive: true, force: true });
+  });
+
+  return {
+    socketDir,
+    socketPath,
+    waitForNextSocketClose: () =>
+      new Promise<void>((resolve) => {
+        closeWaiters.push(resolve);
+      }),
+  };
+}
+
+async function importConnection(socketDir: string, socketPath: string) {
+  process.env.OPENMUX_SHIM_SOCKET_DIR = socketDir;
+  process.env.OPENMUX_SHIM_SOCKET_PATH = socketPath;
+  return import(`../../src/shim/client/connection.ts?connectionLifecycle=${importNonce++}`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+afterEach(async () => {
+  while (cleanupTasks.length > 0) {
+    await cleanupTasks.pop()?.();
+  }
+  delete process.env.OPENMUX_SHIM_SOCKET_DIR;
+  delete process.env.OPENMUX_SHIM_SOCKET_PATH;
+});
+
+describe('shim connection lifecycle', () => {
+  test('rejects pending requests when the socket closes before response', async () => {
+    const server = await createShimTestServer((header, _payloads, socket) => {
+      if (header.method === 'hang') {
+        socket.end();
+        return;
+      }
+
+      sendResponse(socket, header, { pid: process.pid });
+    });
+    const connection = await importConnection(server.socketDir, server.socketPath);
+
+    const result = await Promise.race([
+      connection.sendRequest('hang', {}, [], 500).then(
+        () => 'resolved',
+        (error: Error) => error
+      ),
+      delay(150).then(() => 'timed out'),
+    ]);
+
+    expect(result).not.toBe('timed out');
+    expect(result).not.toBe('resolved');
+    expect((result as Error).message).toContain('Shim socket closed');
+  });
+
+  test('reconnects after an ordinary socket close', async () => {
+    const server = await createShimTestServer((header, _payloads, socket) => {
+      if (header.method === 'closeAfterResponse') {
+        sendResponse(socket, header);
+        socket.end();
+        return;
+      }
+
+      if (header.method === 'afterReconnect') {
+        sendResponse(socket, header, { value: 'ok' });
+        return;
+      }
+
+      sendResponse(socket, header, { pid: process.pid });
+    });
+    const connection = await importConnection(server.socketDir, server.socketPath);
+
+    const socketClosed = server.waitForNextSocketClose();
+    await connection.sendRequest('closeAfterResponse', {}, [], 500);
+    await socketClosed;
+    await delay(10);
+
+    const response = await connection.sendRequest('afterReconnect', {}, [], 500);
+
+    expect(response.header.result).toEqual({ value: 'ok' });
+  });
+
+  test('keeps explicit detached events terminal for the client', async () => {
+    const server = await createShimTestServer((header, _payloads, socket) => {
+      if (header.method === 'detachMe') {
+        socket.write(encodeTestFrame({ type: 'detached' }));
+        socket.end();
+        return;
+      }
+
+      sendResponse(socket, header, { pid: process.pid });
+    });
+    const connection = await importConnection(server.socketDir, server.socketPath);
+    let detachNotifications = 0;
+    const unsubscribe = connection.onShimDetached(() => {
+      detachNotifications += 1;
+    });
+
+    const detachResult = await connection.sendRequest('detachMe', {}, [], 500).catch((e) => e);
+    const reconnectResult = await connection
+      .sendRequest('afterDetach', {}, [], 500)
+      .catch((e) => e);
+
+    unsubscribe();
+
+    expect(detachNotifications).toBe(1);
+    expect((detachResult as Error).message).toContain('Shim client detached');
+    expect((reconnectResult as Error).message).toContain('Shim client detached');
+  });
+});


### PR DESCRIPTION
## Summary

Pending shim requests previously had no terminal state when the transport failed — they sat in the `pendingRequests` map forever, hanging any UI flow that awaited them. This PR makes every disconnect path settle the promise with a `ShimConnectionError`.

### Changes
- **Reject pending requests on socket close** — plain transport close now rejects with `Shim socket closed` (not `markDetached()`).
- **Reject pending requests on explicit detach** — `markDetached()` now rejects in-flight work with `Shim client detached` before notifying subscribers.
- **Distinguish transport close from protocol detach** — plain `close` events no longer flip the terminal `detached` flag, so reconnection after a server restart works.
- **Per-request timeout on `sendRequest`** — defaults to 30 s; tracked via the `PendingRequest.timeout` field and cleared in `takePendingRequest`. Open question: 30 s is generous for an interactive UI; specific call sites may want shorter.
- **Write-error path** — `socket.write` failures now reject the same pending entry instead of leaving it dangling.
- **Stale-close guard** — `clearSocketState` only clears state if the closed socket is still the current one (prevents an old socket's late close from wiping a new connection).
- **Env-var override for socket path** — `OPENMUX_SHIM_SOCKET_DIR` / `OPENMUX_SHIM_SOCKET_PATH` so tests can substitute a fake server.

## How to reproduce the bug (on `main`)

The repro relies on the env-var override that this PR adds, so to run the new test against `main` you have to apply just that part as a temp patch:

1. `git checkout main`
2. In `src/shim/client/connection.ts`, add the two helpers and use them in `connectSocket`:
   ```ts
   function getShimSocketDir() { return process.env.OPENMUX_SHIM_SOCKET_DIR ?? SHIM_SOCKET_DIR; }
   function getShimSocketPath() { return process.env.OPENMUX_SHIM_SOCKET_PATH ?? SHIM_SOCKET_PATH; }
   // replace SHIM_SOCKET_DIR / SHIM_SOCKET_PATH at the two call sites in connectSocket()
   ```
3. Copy this branch's `tests/shim/connection-lifecycle.test.ts` over.
4. `bun test tests/shim/connection-lifecycle.test.ts`

Expected on `main` (bug):
- `rejects pending requests when the socket closes before response` → **fail** (the `Promise.race` wins with `'timed out'` because `sendRequest` never settles).
- `reconnects after an ordinary socket close` → **fail** with `Shim client detached` (plain close incorrectly trips `markDetached()`).
- `keeps explicit detached events terminal for the client` → **fail** with bun:test's 5 s timeout (pending request never rejected on detach).

Expected on this branch: all three pass (verified locally).

## Validation
- `bun test tests/shim/connection-lifecycle.test.ts` → 3/3 pass
- `bun run typecheck` → clean


---
_Recreated from #21 (auto-closed when the head branch was briefly deleted during a fork migration; identical diff)._
